### PR TITLE
README: Remove support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,3 @@ $ make ARCH=x86_64 check
 $ make ARCH=x86_64 DESTDIR=out install
 ```
 
-
-## support
-
-`libucontext` is offered as part of the `gcompat` project.  Accordingly, please address all questions
-and bug reports to gcompat@lists.adelielinux.org.


### PR DESCRIPTION
This is no longer a member of the gcompat family of projects;
remove the mention of that and the gcompat mailing list link.