### PR TITLE
x86: Update copyright statement

### DIFF
--- a/arch/x86/makecontext.c
+++ b/arch/x86/makecontext.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Ariadne Conill <ariadne@dereferenced.org>
+ * Copyright (c) 2019 A. Wilcox <awilfox@adelielinux.org>
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
Commit d0ccf2f96f12bfa040cc056f7dc26b3fd25c168d contains the makecontext fix AdelieLinux/libucontext@aaeb73ea – but it didn't include the addition of my author line.

The full commit text, for future documentation/reference, was:

```
x86: Write link pointer at correct stack offset

It must come *after* the parameters, not *before*.
```

Fixes: d0ccf2f96f12 ("x86: modernize")