### PR TITLE
ppc, ppc64: tag global symbols as functions

### DIFF
--- a/arch/ppc/getcontext.S
+++ b/arch/ppc/getcontext.S
@@ -12,6 +12,7 @@
 
 .global libucontext_getcontext
 .hidden __libucontext_swapcontext
+.type libucontext_getcontext, @function
 libucontext_getcontext:
 	li 4, 0
 	b __libucontext_swapcontext@local

--- a/arch/ppc/getcontext.S
+++ b/arch/ppc/getcontext.S
@@ -10,12 +10,12 @@
  * from the use of this software.
  */
 
-.global libucontext_getcontext
+#include "common-defs.h"
+
+ALIAS(getcontext, libucontext_getcontext)
+
 .hidden __libucontext_swapcontext
-.type libucontext_getcontext, @function
-libucontext_getcontext:
+FUNC(libucontext_getcontext)
 	li 4, 0
 	b __libucontext_swapcontext@local
-
-.weak getcontext
-getcontext = libucontext_getcontext
+END(libucontext_getcontext)

--- a/arch/ppc/setcontext.S
+++ b/arch/ppc/setcontext.S
@@ -10,13 +10,13 @@
  * from the use of this software.
  */
 
-.global libucontext_setcontext
+#include "common-defs.h"
+
+ALIAS(setcontext, libucontext_setcontext)
+
 .hidden __libucontext_swapcontext
-.type libucontext_setcontext, @function
-libucontext_setcontext:
+FUNC(libucontext_setcontext)
 	mr 4, 3
 	li 3, 0
 	b __libucontext_swapcontext@local
-
-.weak setcontext
-setcontext = libucontext_setcontext
+END(libucontext_setcontext)

--- a/arch/ppc/setcontext.S
+++ b/arch/ppc/setcontext.S
@@ -12,6 +12,7 @@
 
 .global libucontext_setcontext
 .hidden __libucontext_swapcontext
+.type libucontext_setcontext, @function
 libucontext_setcontext:
 	mr 4, 3
 	li 3, 0

--- a/arch/ppc/startcontext.S
+++ b/arch/ppc/startcontext.S
@@ -10,8 +10,10 @@
  * from the use of this software.
  */
 
-.globl libucontext_trampoline;
-libucontext_trampoline:
+#include "common-defs.h"
+
+.hidden libucontext_trampoline
+FUNC(libucontext_trampoline)
 	/* get the proper context into position and test for NULL */
 	mr.	3,31
 
@@ -23,3 +25,4 @@ libucontext_trampoline:
 
 no_linked_context:
 	b	exit@GOT
+END(libucontext_trampoline)

--- a/arch/ppc/swapcontext.S
+++ b/arch/ppc/swapcontext.S
@@ -11,6 +11,7 @@
  */
 
 .global __libucontext_swapcontext
+.type __libucontext_swapcontext, @function
 __libucontext_swapcontext:
 	li 0, 249     # SYS_swapcontext
 	li 5, 1184    # sizeof(ucontext_t)

--- a/arch/ppc/swapcontext.S
+++ b/arch/ppc/swapcontext.S
@@ -10,18 +10,16 @@
  * from the use of this software.
  */
 
-.global __libucontext_swapcontext
-.type __libucontext_swapcontext, @function
-__libucontext_swapcontext:
+#include "common-defs.h"
+
+ALIAS(swapcontext, __libucontext_swapcontext)
+ALIAS(libucontext_swapcontext, __libucontext_swapcontext)
+
+FUNC(__libucontext_swapcontext)
 	li 0, 249     # SYS_swapcontext
 	li 5, 1184    # sizeof(ucontext_t)
 	sc
 
 .hidden __retfromsyscall
 	b __retfromsyscall@local
-
-.weak swapcontext
-swapcontext = libucontext_swapcontext
-
-.weak libucontext_swapcontext
-libucontext_swapcontext = __libucontext_swapcontext
+END(__libucontext_swapcontext)

--- a/arch/ppc64/getcontext.S
+++ b/arch/ppc64/getcontext.S
@@ -12,6 +12,7 @@
 
 .global libucontext_getcontext
 .hidden __libucontext_swapcontext
+.type libucontext_getcontext, @function
 libucontext_getcontext:
 	addis 2, 12, .TOC.-libucontext_getcontext@ha
 	addi  2, 12, .TOC.-libucontext_getcontext@l

--- a/arch/ppc64/getcontext.S
+++ b/arch/ppc64/getcontext.S
@@ -10,10 +10,12 @@
  * from the use of this software.
  */
 
-.global libucontext_getcontext
+#include "common-defs.h"
+
+ALIAS(getcontext, libucontext_getcontext)
+
 .hidden __libucontext_swapcontext
-.type libucontext_getcontext, @function
-libucontext_getcontext:
+FUNC(libucontext_getcontext)
 	addis 2, 12, .TOC.-libucontext_getcontext@ha
 	addi  2, 12, .TOC.-libucontext_getcontext@l
 
@@ -21,6 +23,4 @@ libucontext_getcontext:
 
 	li 4, 0
 	b __libucontext_swapcontext
-
-.weak getcontext
-getcontext = libucontext_getcontext
+END(libucontext_getcontext)

--- a/arch/ppc64/setcontext.S
+++ b/arch/ppc64/setcontext.S
@@ -12,6 +12,7 @@
 
 .global libucontext_setcontext
 .hidden __libucontext_swapcontext
+.type libucontext_setcontext, @function
 libucontext_setcontext:
 	addis 2, 12, .TOC.-libucontext_setcontext@ha
 	addi  2, 12, .TOC.-libucontext_setcontext@l

--- a/arch/ppc64/setcontext.S
+++ b/arch/ppc64/setcontext.S
@@ -10,10 +10,12 @@
  * from the use of this software.
  */
 
-.global libucontext_setcontext
+#include "common-defs.h"
+
+ALIAS(setcontext, libucontext_setcontext)
+
 .hidden __libucontext_swapcontext
-.type libucontext_setcontext, @function
-libucontext_setcontext:
+FUNC(libucontext_setcontext)
 	addis 2, 12, .TOC.-libucontext_setcontext@ha
 	addi  2, 12, .TOC.-libucontext_setcontext@l
 
@@ -22,6 +24,4 @@ libucontext_setcontext:
 	mr 4, 3
 	li 3, 0
 	b __libucontext_swapcontext
-
-.weak setcontext
-setcontext = libucontext_setcontext
+END(libucontext_setcontext)

--- a/arch/ppc64/startcontext.S
+++ b/arch/ppc64/startcontext.S
@@ -10,9 +10,10 @@
  * from the use of this software.
  */
 
-.globl libucontext_trampoline;
-.hidden libucontext_trampoline;
-libucontext_trampoline:
+#include "common-defs.h"
+
+.hidden libucontext_trampoline
+FUNC(libucontext_trampoline)
 	cmpdi	31,0			/* test if ucontext link pointer is null */
 	beq	no_linked_context	/* if it is, exit */
 
@@ -29,3 +30,4 @@ libucontext_trampoline:
 no_linked_context:
 	b	exit@GOT
 	nop
+END(libucontext_trampoline)

--- a/arch/ppc64/swapcontext.S
+++ b/arch/ppc64/swapcontext.S
@@ -11,6 +11,7 @@
  */
 
 .global __libucontext_swapcontext
+.type __libucontext_swapcontext, @function
 __libucontext_swapcontext:
 	addis 2, 12, .TOC.-__libucontext_swapcontext@ha
 	addi  2, 12, .TOC.-__libucontext_swapcontext@l

--- a/arch/ppc64/swapcontext.S
+++ b/arch/ppc64/swapcontext.S
@@ -10,9 +10,12 @@
  * from the use of this software.
  */
 
-.global __libucontext_swapcontext
-.type __libucontext_swapcontext, @function
-__libucontext_swapcontext:
+#include "common-defs.h"
+
+ALIAS(swapcontext, __libucontext_swapcontext)
+ALIAS(libucontext_swapcontext, __libucontext_swapcontext)
+
+FUNC(__libucontext_swapcontext)
 	addis 2, 12, .TOC.-__libucontext_swapcontext@ha
 	addi  2, 12, .TOC.-__libucontext_swapcontext@l
 
@@ -24,9 +27,4 @@ __libucontext_swapcontext:
 
 .hidden __retfromsyscall
 	b __retfromsyscall
-
-.weak swapcontext
-swapcontext = __libucontext_swapcontext
-
-.weak libucontext_swapcontext
-libucontext_swapcontext = __libucontext_swapcontext
+END(__libucontext_swapcontext)


### PR DESCRIPTION
it is necessary to tag these symbols as functions otherwise the linker gets confused; this previously manifested as the internal
functions (pre-rename) like `__getcontext` leaking into the symbol table of things linked against `libucontext` that used the `ucontext` POSIX API through the weak aliases

it also had another bad effect and that is if you tried to use `libucontext`'s API (post-rename), the linker would warn you during
compile time that the type is unknown, and the resulting program would crash at runtime

after properly tagging everything, I no longer notice any leakage, i.e. there don't seem to be any references to the aliased symbols
in the resulting symbol table when using the aliases, and using the `libucontext` prefixed symbols directly also works

we talked about this in IRC previously, and I wanted to finally get this out of the way; after this is fixed it'll be needed to bump soname for next release