### PR TITLE
Fix ARCH deduction on armv7l when using Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ endif
 ifeq ($(ARCH),$(filter $(ARCH),ppc64le))
 	override ARCH = ppc64
 endif
+ifeq ($(ARCH),$(filter $(ARCH),armv7l))
+	override ARCH = arm
+endif
 
 LIBDIR := /lib
 INCLUDEDIR := /usr/include


### PR DESCRIPTION
The Makefile on ARMv7l devices (e.g. Raspberry Pi 400 running the stock Raspbian distro) was failing to deduct the architecture and empty libraries were being built as a result.  Building with Meson works fine; only building with make generated empty libraries.

Add an override for armv7l -> arm in the Makefile to address this.