### PR TITLE
meson: Add option to pass cpu

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,11 @@ project(
   version : run_command('head', files('VERSION')).stdout()
 )
 
-cpu = host_machine.cpu_family()
+cpu = get_option('cpu')
+if cpu == ''
+  cpu = host_machine.cpu_family()
+endif
+
 if cpu == 'sh4'
   cpu = 'sh'
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,5 @@ option('freestanding', type : 'boolean', value : false,
        description: 'Do not use system headers')
 option('export_unprefixed', type : 'boolean', value : true,
        description: 'Export POSIX 2004 ucontext names as alises')
+option('cpu', type : 'string', value : '',
+       description: 'Target CPU architecture for cross compile')


### PR DESCRIPTION
This helps with cross compile setups, where host_cpu != target_cpu
therefore detecting it on the fly will end up with wrong cpu to build
for

Signed-off-by: Khem Raj <raj.khem@gmail.com>