### PR TITLE
Disable executable stack by adding note in assembly files

### DIFF
--- a/arch/aarch64/getcontext.S
+++ b/arch/aarch64/getcontext.S
@@ -59,3 +59,6 @@ PROC_NAME(libucontext_getcontext):
 	mov	x0, #0
 	ret
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/aarch64/setcontext.S
+++ b/arch/aarch64/setcontext.S
@@ -51,3 +51,6 @@ PROC_NAME(libucontext_setcontext):
 	/* jump to new PC */
 	br	x16
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/aarch64/swapcontext.S
+++ b/arch/aarch64/swapcontext.S
@@ -67,3 +67,6 @@ PROC_NAME(libucontext_swapcontext):
 	mov	x30, x28
 	ret
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/arm/getcontext.S
+++ b/arch/arm/getcontext.S
@@ -26,3 +26,6 @@ FUNC(libucontext_getcontext)
 	mov	r0, #0
 	mov	pc, lr
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/arm/setcontext.S
+++ b/arch/arm/setcontext.S
@@ -25,3 +25,6 @@ FUNC(libucontext_setcontext)
 	/* load link register and jump to new context */
 	ldmia	r14, {r14, pc}
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/arm/swapcontext.S
+++ b/arch/arm/swapcontext.S
@@ -29,3 +29,6 @@ FUNC(libucontext_swapcontext)
 	add	r14, r14, #56
 	ldmia	r14, {r14, pc}
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/loongarch64/getcontext.S
+++ b/arch/loongarch64/getcontext.S
@@ -44,3 +44,6 @@ FUNC(libucontext_getcontext)
 
 	jr	$ra
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/loongarch64/makecontext.S
+++ b/arch/loongarch64/makecontext.S
@@ -106,3 +106,6 @@ no_more_arguments:
 
 	jr	$ra
 END(libucontext_makecontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/loongarch64/setcontext.S
+++ b/arch/loongarch64/setcontext.S
@@ -53,3 +53,6 @@ FUNC(libucontext_setcontext)
 
 	POP_FRAME(libucontext_setcontext)
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/loongarch64/startcontext.S
+++ b/arch/loongarch64/startcontext.S
@@ -31,3 +31,6 @@ no_linked_context:
 	jr	$t8
 
 END(libucontext_trampoline)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/loongarch64/swapcontext.S
+++ b/arch/loongarch64/swapcontext.S
@@ -87,3 +87,6 @@ fail:
 	jirl	$ra, $t8, 0
 	move	$v0, $zero
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/m68k/getcontext.S
+++ b/arch/m68k/getcontext.S
@@ -28,3 +28,6 @@ FUNC(libucontext_getcontext)
 	clr.l		%d0					/* return 0 */
 	rts
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/m68k/setcontext.S
+++ b/arch/m68k/setcontext.S
@@ -29,3 +29,6 @@ FUNC(libucontext_setcontext)
 
 	jmp		(%a1)					/* jump to *$a1 */
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/m68k/swapcontext.S
+++ b/arch/m68k/swapcontext.S
@@ -38,3 +38,6 @@ FUNC(libucontext_swapcontext)
 
 	jmp		(%a1)					/* jump to *$a1 */
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips/getcontext.S
+++ b/arch/mips/getcontext.S
@@ -45,3 +45,6 @@ FUNC(libucontext_getcontext)
 
 	jr	$ra
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips/makecontext.S
+++ b/arch/mips/makecontext.S
@@ -99,3 +99,6 @@ no_more_arguments:
 
 	jr	$ra
 END(libucontext_makecontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips/setcontext.S
+++ b/arch/mips/setcontext.S
@@ -49,3 +49,6 @@ FUNC(libucontext_setcontext)
 
 	POP_FRAME(libucontext_setcontext)
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips/startcontext.S
+++ b/arch/mips/startcontext.S
@@ -33,3 +33,6 @@ no_linked_context:
 	jalr	$t9
 	nop
 END(libucontext_trampoline)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips/swapcontext.S
+++ b/arch/mips/swapcontext.S
@@ -80,3 +80,6 @@ fail:
 	move	$v0, $zero
 	jalr	$t9
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips64/getcontext.S
+++ b/arch/mips64/getcontext.S
@@ -45,3 +45,6 @@ FUNC(libucontext_getcontext)
 
 	jr	$ra
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips64/makecontext.S
+++ b/arch/mips64/makecontext.S
@@ -105,3 +105,6 @@ no_more_arguments:
 
 	jr	$ra
 END(libucontext_makecontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips64/setcontext.S
+++ b/arch/mips64/setcontext.S
@@ -53,3 +53,6 @@ FUNC(libucontext_setcontext)
 
 	POP_FRAME(libucontext_setcontext)
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips64/startcontext.S
+++ b/arch/mips64/startcontext.S
@@ -33,3 +33,6 @@ no_linked_context:
 	jalr	$t9
 	nop
 END(libucontext_trampoline)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/mips64/swapcontext.S
+++ b/arch/mips64/swapcontext.S
@@ -85,3 +85,6 @@ fail:
 	move	$v0, $zero
 	jalr	$t9
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/ppc/getcontext.S
+++ b/arch/ppc/getcontext.S
@@ -20,3 +20,6 @@ FUNC(libucontext_getcontext)
 	li 4, 0
 	b __libucontext_swapcontext@local
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/ppc/setcontext.S
+++ b/arch/ppc/setcontext.S
@@ -21,3 +21,6 @@ FUNC(libucontext_setcontext)
 	li 3, 0
 	b __libucontext_swapcontext@local
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/ppc/startcontext.S
+++ b/arch/ppc/startcontext.S
@@ -26,3 +26,6 @@ FUNC(libucontext_trampoline)
 no_linked_context:
 	b	exit@GOT
 END(libucontext_trampoline)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/ppc/swapcontext.S
+++ b/arch/ppc/swapcontext.S
@@ -27,3 +27,6 @@ FUNC(__libucontext_swapcontext)
 .hidden __retfromsyscall
 	b __retfromsyscall@local
 END(__libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/ppc64/getcontext.S
+++ b/arch/ppc64/getcontext.S
@@ -25,3 +25,6 @@ FUNC(libucontext_getcontext)
 	li 4, 0
 	b __libucontext_swapcontext
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/ppc64/setcontext.S
+++ b/arch/ppc64/setcontext.S
@@ -26,3 +26,6 @@ FUNC(libucontext_setcontext)
 	li 3, 0
 	b __libucontext_swapcontext
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/ppc64/startcontext.S
+++ b/arch/ppc64/startcontext.S
@@ -31,3 +31,6 @@ no_linked_context:
 	b	exit@GOT
 	nop
 END(libucontext_trampoline)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/ppc64/swapcontext.S
+++ b/arch/ppc64/swapcontext.S
@@ -32,3 +32,6 @@ FUNC(__libucontext_swapcontext)
 .hidden __retfromsyscall
 	b __retfromsyscall
 END(__libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/riscv32/getcontext.S
+++ b/arch/riscv32/getcontext.S
@@ -43,3 +43,6 @@ FUNC(libucontext_getcontext)
 	/* done saving, return */
 	ret
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/riscv32/setcontext.S
+++ b/arch/riscv32/setcontext.S
@@ -54,3 +54,6 @@ FUNC(libucontext_setcontext)
 	/* done restoring, jump to new pc in S1 */
 	jr t1
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/riscv32/swapcontext.S
+++ b/arch/riscv32/swapcontext.S
@@ -79,3 +79,6 @@ FUNC(libucontext_swapcontext)
 	/* done swapping, jump to new PC in S1 */
 	jr t1
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/riscv64/getcontext.S
+++ b/arch/riscv64/getcontext.S
@@ -43,3 +43,6 @@ FUNC(libucontext_getcontext)
 	/* done saving, return */
 	ret
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/riscv64/setcontext.S
+++ b/arch/riscv64/setcontext.S
@@ -54,3 +54,6 @@ FUNC(libucontext_setcontext)
 	/* done restoring, jump to new pc in S1 */
 	jr t1
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/riscv64/swapcontext.S
+++ b/arch/riscv64/swapcontext.S
@@ -79,3 +79,6 @@ FUNC(libucontext_swapcontext)
 	/* done swapping, jump to new PC in S1 */
 	jr t1
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/s390x/getcontext.S
+++ b/arch/s390x/getcontext.S
@@ -24,3 +24,6 @@ FUNC(libucontext_getcontext)
 
 	br	%r14				/* return to where we came from */
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/s390x/setcontext.S
+++ b/arch/s390x/setcontext.S
@@ -23,3 +23,6 @@ FUNC(libucontext_setcontext)
 
 	br	%r14				/* return to new link register address */
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/s390x/startcontext.S
+++ b/arch/s390x/startcontext.S
@@ -28,3 +28,6 @@ no_linked_context:
 
 	j	.+2				/* crash if exit returns */
 END(libucontext_trampoline)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/s390x/swapcontext.S
+++ b/arch/s390x/swapcontext.S
@@ -28,3 +28,6 @@ FUNC(libucontext_swapcontext)
 
 	br	%r14				/* return to new link register address */
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/sh/getcontext.S
+++ b/arch/sh/getcontext.S
@@ -54,3 +54,6 @@ FUNC(libucontext_getcontext)
 	mov	#0, r0						/* set return value as zero */
 	rts
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/sh/setcontext.S
+++ b/arch/sh/setcontext.S
@@ -58,3 +58,6 @@ FUNC(libucontext_setcontext)
 
 	mov.l	@r15+, r0					/* pop original r0 from stack */
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/sh/swapcontext.S
+++ b/arch/sh/swapcontext.S
@@ -93,3 +93,6 @@ FUNC(libucontext_swapcontext)
 
 	mov.l	@r15+, r0					/* pop original r0 from stack */
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/x86/getcontext.S
+++ b/arch/x86/getcontext.S
@@ -48,3 +48,6 @@ FUNC(libucontext_getcontext)
 	xorl	%eax, %eax
 	ret
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/x86/setcontext.S
+++ b/arch/x86/setcontext.S
@@ -43,3 +43,6 @@ FUNC(libucontext_setcontext)
 
 	ret
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/x86/swapcontext.S
+++ b/arch/x86/swapcontext.S
@@ -71,3 +71,6 @@ FUNC(libucontext_swapcontext)
 
 	ret
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/x86_64/getcontext.S
+++ b/arch/x86_64/getcontext.S
@@ -47,3 +47,6 @@ FUNC(libucontext_getcontext)
 	xorl	%eax, %eax
 	ret
 END(libucontext_getcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/x86_64/setcontext.S
+++ b/arch/x86_64/setcontext.S
@@ -44,3 +44,6 @@ FUNC(libucontext_setcontext)
 	xorl	%eax, %eax
 	ret
 END(libucontext_setcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arch/x86_64/swapcontext.S
+++ b/arch/x86_64/swapcontext.S
@@ -73,3 +73,6 @@ FUNC(libucontext_swapcontext)
 	xorl	%eax, %eax
 	ret
 END(libucontext_swapcontext)
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
I don't use libucontext much, but I finally got around  to version 1.1, and since I finally turned on some extra QA output  for Gentoo I got this warning.

```
* QA Notice: The following files contain writable and executable sections
 *  Files with such sections will not work properly (or at all!) on some
 *  architectures/operating systems.  A bug should be filed at
 *  https://bugs.gentoo.org/ to make sure the issue is fixed.
 *  For more information, see:
 *
 *    https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart
 *
 *  Please include the following list of files in your report:
 *  Note: Bugs should be filed for the respective maintainers
 *  of the package in question and not hardened@gentoo.org.
 * !WX --- --- usr/lib64/libucontext_posix.a:arch_x86_64_getcontext.S.o
 * !WX --- --- usr/lib64/libucontext_posix.a:arch_x86_64_setcontext.S.o
 * !WX --- --- usr/lib64/libucontext_posix.a:arch_x86_64_swapcontext.S.o
 * !WX --- --- usr/lib64/libucontext.a:arch_x86_64_getcontext.S.o
 * !WX --- --- usr/lib64/libucontext.a:arch_x86_64_setcontext.S.o
 * !WX --- --- usr/lib64/libucontext.a:arch_x86_64_swapcontext.S.o
```

I checked and saw that the assembly files indeed didn't have a note indicating if they needed an executable stack or not.

It seems this only happens when built under glibc.

If you would take a look, and do some more testing to ensure things don't break ( the basic make check passes still under musl, but the second test segfaults on glibc both with and without this change)

[Gentoo bug](https://bugs.gentoo.org/828137) filed by someone else.