### PR TITLE
Fixed empty TYPE(__proc) causing linker issues on 32-bit arm

### DIFF
--- a/arch/arm/defs.h
+++ b/arch/arm/defs.h
@@ -3,7 +3,7 @@
 #define REG_SZ		(4)
 #define MCONTEXT_GREGS	(32)
 
-#define TYPE(__proc)
+#define TYPE(__proc)	.type	__proc, %function;
 
 #define FETCH_LINKPTR(dest) \
 	asm("movs    %0, r4" : "=r" ((dest)))


### PR DESCRIPTION
The lack of ".type __proc, %function" caused linker warnings when dynamic linking, and a segfault at runtime when static linking