### PR TITLE
Fix FREESTANDING install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ install: all
 		install -D -m644 $$i ${DESTDIR}${INCLUDEDIR}/$$destfn; \
 	done
 	install -D -m644 ${LIBUCONTEXT_PC} ${DESTDIR}${PKGCONFIGDIR}/${LIBUCONTEXT_PC}
-	if [ -n ${LIBUCONTEXT_POSIX_NAME} ]; then \
+	if [ -n "${LIBUCONTEXT_POSIX_NAME}" ]; then \
 		install -D -m755 ${LIBUCONTEXT_POSIX_NAME} ${DESTDIR}${LIBUCONTEXT_POSIX_PATH}; \
 		install -D -m644 ${LIBUCONTEXT_POSIX_STATIC_NAME} ${DESTDIR}${LIBUCONTEXT_POSIX_STATIC_PATH}; \
 	fi


### PR DESCRIPTION
When installing a FREESTANDING build, the check for an empty variable was not being honored because the empty string would evaluate to nothing, making the condition pass and ultimately make the makefile target to fail.  Put the variable expansion in quotes so that we have an empty string instead.