### PR TITLE
Set _XOPEN_SOURCE when building on Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ ifneq ($(shell uname),Darwin)
 else
 	# Darwin does not support aliases
 	EXPORT_UNPREFIXED := no
+	CPPFLAGS += -D_XOPEN_SOURCE
 endif
 FREESTANDING := no
 


### PR DESCRIPTION
On non-freestanding builds, including `<ucontext.h>` on an ARM Darwin
system will produce the following error:

    In file included from include/libucontext/bits.h:6:
    /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/
	  usr/include/ucontext.h:51:2: error: The deprecated
      ucontext routines require _XOPEN_SOURCE to be defined

Defining this macro on Darwin systems will make the building pass.

(I don't have an ARM Darwin system; this is just a speculative fix from looking at a [build log](https://gist.github.com/rchiossi/08c7390b78e4e94b7bb96d88275ca7fd) that has been sent to me for a personal project.)