### PR TITLE
meson: support building docs

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,21 @@
+scdoc = find_program('scdoc', required: true)
+
+custom_target(
+  'libucontext.3',
+  output: 'libucontext.3',
+  input: 'libucontext.scd',
+  command: [ scdoc ],
+  feed: true,
+  capture: true,
+  install: true,
+  install_dir: get_option('mandir') / 'man3'
+)
+
+if meson.version().version_compare('>=0.61.0')
+  foreach link : [ 'get', 'make', 'set', 'swap' ]
+    install_symlink('libucontext_' + link + 'context.3',
+      pointing_to: 'libucontext.3',
+      install_dir: get_option('mandir') / 'man3'
+    )
+  endforeach
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'libucontext',
   'c',
-  meson_version : '>=0.55.0',
+  meson_version : '>=0.59.0',
   default_options: ['c_std=gnu11', 'default_library=both'],
   version : run_command('head', files('VERSION')).stdout()
 )
@@ -144,9 +144,8 @@ endif
 # Docs
 # ====
 
-# TODO: meson.build for docs
-if not meson.is_subproject()
-  #subdir('docs')
+if not meson.is_subproject() and get_option('docs')
+  subdir('doc')
 endif
 
 # ==========

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,5 @@ option('export_unprefixed', type : 'boolean', value : true,
        description: 'Export POSIX 2004 ucontext names as alises')
 option('cpu', type : 'string', value : '',
        description: 'Target CPU architecture for cross compile')
+option('docs', type : 'boolean', value : false,
+       description: 'Build and install man pages')


### PR DESCRIPTION
Toggleable with -Ddocs=(true|false), defaults to false.

Requires bumping minimum meson version to 0.59.0, or 0.61.0 to also include symlinks.