### PR TITLE
arm: Add patch fixing return values of get/set/swapcontext

### DIFF
--- a/arch/arm/swapcontext.S
+++ b/arch/arm/swapcontext.S
@@ -16,12 +16,6 @@ ALIAS(swapcontext, libucontext_swapcontext)
 ALIAS(__swapcontext, libucontext_swapcontext)
 
 FUNC(libucontext_swapcontext)
-	/* copy all of the current registers into the ucontext structure */
-	add	r2, r0, #REG_OFFSET(0)
-	stmia	r2, {r0-r12}
-	str	r13, [r0,#REG_OFFSET(13)]
-	str	r14, [r0,#REG_OFFSET(15)]
-
 #ifndef FORCE_SOFT_FLOAT
 #ifndef FORCE_HARD_FLOAT
 	/* test for vfp magic number, copy to other ucontext */
@@ -42,6 +36,14 @@ FUNC(libucontext_swapcontext)
 1:
 #endif
 
+ 	/* copy all of the current registers into the ucontext structure */
+ 	str	r13, [r0,#REG_OFFSET(13)]
+ 	str	r14, [r0,#REG_OFFSET(15)]
+	add	r2, r0, #REG_OFFSET(0)
+	/* copy r0 with value 0 to indicate success (return value 0) */
+	mov r0, #0
+	stmia	r2, {r0-r12}
+	
 	/* load new registers from the second ucontext structure */
 	add	r14, r1, #REG_OFFSET(0)
 	ldmia	r14, {r0-r12}


### PR DESCRIPTION
Finally i dived deeper into the code for ARM and refreshed my assembly knowledge and found a fix for #55 ("Aieie, swapcontext() failed ...").

The arm ABI defines that the value in register r0 is used as the return value of a function. To indicate success for get/set/swapcontext (return value of 0) the register r0 must contain zero when get/set/swapcontext return. Thus set r0 to zero and store it in the context. This context is retrieved later before get/set/swapcontext return and thus it indicate successful execution, because r0 is 0.

The order registers are stored has changed so that only one additional instruction (mov r0, #0) needs to be added to fix the return value bug for get/set/swapcontext.

Best regards
Volker