### PR TITLE
aarch64: Fix return value if getcontext was used to acquire the current context

### DIFF
--- a/arch/aarch64/getcontext.S
+++ b/arch/aarch64/getcontext.S
@@ -22,23 +22,8 @@ ALIAS(__getcontext, libucontext_getcontext)
 PROC_NAME(libucontext_getcontext):
 	str	xzr, [x0, #REG_OFFSET(0)]
 
-	/* save GPRs */
-	stp	x0, x1,   [x0, #REG_OFFSET(0)]
+	/* save x2 and x3 for reuse */
 	stp	x2, x3,   [x0, #REG_OFFSET(2)]
-	stp	x4, x5,   [x0, #REG_OFFSET(4)]
-	stp	x6, x7,   [x0, #REG_OFFSET(6)]
-	stp	x8, x9,   [x0, #REG_OFFSET(8)]
-	stp	x10, x11, [x0, #REG_OFFSET(10)]
-	stp	x12, x13, [x0, #REG_OFFSET(12)]
-	stp	x14, x15, [x0, #REG_OFFSET(14)]
-	stp	x16, x17, [x0, #REG_OFFSET(16)]
-	stp	x18, x19, [x0, #REG_OFFSET(18)]
-	stp	x20, x21, [x0, #REG_OFFSET(20)]
-	stp	x22, x23, [x0, #REG_OFFSET(22)]
-	stp	x24, x25, [x0, #REG_OFFSET(24)]
-	stp	x26, x27, [x0, #REG_OFFSET(26)]
-	stp	x28, x29, [x0, #REG_OFFSET(28)]
-	str	x30,      [x0, #REG_OFFSET(30)]
 
 	/* save current program counter in link register */
 	str	x30, [x0, #PC_OFFSET]
@@ -56,6 +41,26 @@ PROC_NAME(libucontext_getcontext):
 	stp q12, q13, [x2, #208]
 	stp q14, q15, [x2, #240]
 
+	/* save GPRs and return value 0 */
+	mov	x2, x0
 	mov	x0, #0
+
+	stp	x0, x1,   [x2, #REG_OFFSET(0)]
+	/* x2 and x3 have already been saved */
+	stp	x4, x5,   [x2, #REG_OFFSET(4)]
+	stp	x6, x7,   [x2, #REG_OFFSET(6)]
+	stp	x8, x9,   [x2, #REG_OFFSET(8)]
+	stp	x10, x11, [x2, #REG_OFFSET(10)]
+	stp	x12, x13, [x2, #REG_OFFSET(12)]
+	stp	x14, x15, [x2, #REG_OFFSET(14)]
+	stp	x16, x17, [x2, #REG_OFFSET(16)]
+	stp	x18, x19, [x2, #REG_OFFSET(18)]
+	stp	x20, x21, [x2, #REG_OFFSET(20)]
+	stp	x22, x23, [x2, #REG_OFFSET(22)]
+	stp	x24, x25, [x2, #REG_OFFSET(24)]
+	stp	x26, x27, [x2, #REG_OFFSET(26)]
+	stp	x28, x29, [x2, #REG_OFFSET(28)]
+	str	x30,      [x2, #REG_OFFSET(30)]
+
 	ret
 END(libucontext_getcontext)


### PR DESCRIPTION
x0 hast to be 0 in case setcontext is called with a context acquired by getcontext. 
Thus x0 must be stored in getcontext as 0.