### PR TITLE
build: fix CPPFLAG include directory for freestanding mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ endif
 FREESTANDING := no
 
 ifeq ($(FREESTANDING),yes)
-	CPPFLAGS += -DFREESTANDING
-	EXPORT_UNPREFIXED = no -Iarch/${ARCH}/include
+	CPPFLAGS += -DFREESTANDING -Iarch/${ARCH}/include
+	EXPORT_UNPREFIXED = no
 else
 	CPPFLAGS += -Iarch/common/include
 endif


### PR DESCRIPTION
`-Iarch/${ARCH}/include` was being assigned to `EXPORT_UNPREFIXED` instead of `CPPFLAGS`.

This fixes the following compile error:

```
# make FREESTANDING=yes


cc -std=gnu99 -D_DEFAULT_SOURCE -fPIC -DPIC -ggdb3 -O2 -Wall -Iinclude -Iarch/x86_64 -Iarch/common -DFREESTANDING -DFORCE_SOFT_FLOAT -c -o arch/x86_64/makecontext.o arch/x86_64/makecontext.c
In file included from arch/x86_64/makecontext.c:19:
include/libucontext/libucontext.h:5:10: fatal error: libucontext/bits.h: No such file or directory
    5 | #include <libucontext/bits.h>
      |          ^~~~~~~~~~~~~~~~~~~~
```