### PR TITLE
build: fix install path of headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,8 +215,8 @@ install: all
 	install -D -m664 ${LIBUCONTEXT_STATIC_NAME} ${DESTDIR}${LIBUCONTEXT_STATIC_PATH}
 	ln -sf ${LIBUCONTEXT_SONAME} ${DESTDIR}${shared_libdir}/${LIBUCONTEXT_NAME}
 	for i in ${LIBUCONTEXT_HEADERS}; do \
-		destfn=$$(echo $$i | sed s:include/::g); \
-		install -D -m644 $$i ${DESTDIR}${includedir}/$$destfn; \
+		destfn=$$(basename $$i); \
+		install -D -m644 $$i ${DESTDIR}${includedir}/$(basename $(LIBUCONTEXT_NAME))/$$destfn; \
 	done
 	install -D -m644 ${LIBUCONTEXT_PC} ${DESTDIR}${pkgconfigdir}/${LIBUCONTEXT_PC}
 	if [ -n "${LIBUCONTEXT_POSIX_NAME}" ]; then \


### PR DESCRIPTION
Install `bits.h` into `/usr/include/libucontext/bits.h` instead of into `/usr/include/libucontext/arch/common/libucontext/bits.h` (in case `/usr/include` is the include dir to install in).