### PR TITLE
fix build on aarch64

### DIFF
--- a/arch/aarch64/include/libucontext/bits.h
+++ b/arch/aarch64/include/libucontext/bits.h
@@ -11,10 +11,10 @@ typedef struct {
 } libucontext_fpregset_t;
 
 typedef struct sigcontext {
-	unsigned long fault_address;
-	unsigned long regs[31];
-	unsigned long sp, pc, pstate;
-	long double __reserved[256];
+	unsigned long long fault_address;
+	unsigned long long regs[31];
+	unsigned long long sp, pc, pstate;
+	unsigned char __reserved[4096] __attribute__((aligned(16)));
 } libucontext_mcontext_t;
 
 typedef struct {

--- a/arch/aarch64/makecontext.c
+++ b/arch/aarch64/makecontext.c
@@ -29,14 +29,14 @@ _Static_assert(offsetof(libucontext_ucontext_t, uc_mcontext.pstate) == PSTATE_OF
 void
 libucontext_makecontext(libucontext_ucontext_t *ucp, void (*func)(void), int argc, ...)
 {
-	unsigned long *sp;
-	unsigned long *regp;
+	unsigned long long *sp;
+	unsigned long long *regp;
 	va_list va;
 	int i;
 
-	sp = (unsigned long *) ((uintptr_t) ucp->uc_stack.ss_sp + ucp->uc_stack.ss_size);
+	sp = (unsigned long long *) ((uintptr_t) ucp->uc_stack.ss_sp + ucp->uc_stack.ss_size);
 	sp -= argc < 8 ? 0 : argc - 8;
-	sp = (unsigned long *) (((uintptr_t) sp & -16L));
+	sp = (unsigned long long *) (((uintptr_t) sp & -16L));
 
 	ucp->uc_mcontext.sp = (uintptr_t) sp;
 	ucp->uc_mcontext.pc = (uintptr_t) func;
@@ -48,10 +48,10 @@ libucontext_makecontext(libucontext_ucontext_t *ucp, void (*func)(void), int arg
 	regp = &(ucp->uc_mcontext.regs[0]);
 
 	for (i = 0; (i < argc && i < 8); i++)
-		*regp++ = va_arg (va, unsigned long);
+		*regp++ = va_arg (va, unsigned long long);
 
 	for (; i < argc; i++)
-		*sp++ = va_arg (va, unsigned long);
+		*sp++ = va_arg (va, unsigned long long);
 
 	va_end(va);
 }


### PR DESCRIPTION
```
$ make
gcc -std=gnu99 -D_DEFAULT_SOURCE -fPIC -DPIC -ggdb3 -O2 -Wall -Iinclude -Iarch/aarch64 -Iarch/common -Iarch/common/include -DFORCE_SOFT_FLOAT -DEXPORT_UNPREFIXED -c -o arch/aarch64/makecontext.o arch/aarch64/makecontext.c
arch/aarch64/makecontext.c: In function ‘libucontext_makecontext’:
arch/aarch64/makecontext.c:48:14: error: assignment to ‘long unsigned int *’ from incompatible pointer type ‘long long unsigned int *’ [-Wincompatible-pointer-types]
   48 |         regp = &(ucp->uc_mcontext.regs[0]);
      |              ^
make: *** [Makefile:155: arch/aarch64/makecontext.o] Error 1
```

this both fixes the build error and fixes the rest of mcontext_t to be compatible with glibc

built on top of the work done in https://github.com/kaniini/libucontext/pull/59 as that patch can't be applied anymore